### PR TITLE
fix: newest subquery failing in sqlite + improve its execution plan

### DIFF
--- a/src/Models/Revision.php
+++ b/src/Models/Revision.php
@@ -32,6 +32,7 @@ use Illuminate\Database\Eloquent\Relations\MorphPivot;
  * @method static Builder|Revision newModelQuery()
  * @method static Builder|Revision newQuery()
  * @method static Builder|Revision query()
+ * @method static \Illuminate\Database\Query\Builder|Revision select($columns = ['*'])
  * @method static Builder|Revision whereId($value)
  * @method static Builder|Revision whereType($value)
  * @method static Builder|Revision whereRevisionableId($value)

--- a/tests/Feature/RevisionableRelationsTest.php
+++ b/tests/Feature/RevisionableRelationsTest.php
@@ -94,6 +94,27 @@ class RevisionableRelationsTest extends TestCase
     /**
      * @test
      */
+    public function retrieve_newest_revisionable(): void
+    {
+        $post = factory(Post::class)->create();
+        $revision1 = $post->revision;
+        $original = clone $post;
+
+        $original_newest_id = $original->newest()->first()->id;
+        $this->assertEquals($post->id, $original_newest_id);
+
+        $post->performRevision();
+        $revision2 = $post->revision;
+        $this->assertEquals($post->id, Post::withNewest()->find($post->id)->newest->id);
+        $this->assertNotEquals($original_newest_id, Post::withNewest()->find($post->id)->newest->id);
+
+        $this->assertEquals($original->id, $revision1->revisionable_id);
+        $this->assertEquals($post->id, $revision2->revisionable_id);
+    }
+
+    /**
+     * @test
+     */
     public function retrieve_all_revisions_from_revisionable(): void
     {
         $post = factory(Post::class)->create();


### PR DESCRIPTION
## Summary

Ensures `withNewest()` scope works on sqlite dbs. The query I previously used worked due on mysql because the deviate from the SQL Standards and allow you to reference previous alias when you have multiple subselects. 

Noticed while trying to add a test to cover this scope. 

### Solution
Use the pre-requisite `withInitial()` scope on the base query and the wrap it in a from sub-select when running `withNewest()` on db drivers that aren't mysql.


see:
- https://stackoverflow.com/questions/10923107/using-a-column-alias-in-sqlite3-where-clause
- https://dba.stackexchange.com/questions/96556/reference-column-alias-in-same-select-list