### PR TITLE
register models in / use models from container

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -39,6 +39,8 @@
             <errorLevel type="suppress">
                 <referencedMethod name="Plank\Checkpoint\Models\Checkpoint::first" />
                 <referencedMethod name="Plank\Checkpoint\Models\Checkpoint::select" />
+                <referencedMethod name="Plank\Checkpoint\Models\Checkpoint::olderThanEquals" />
+                <referencedMethod name="Plank\Checkpoint\Models\Checkpoint::newerThan" />
             </errorLevel>
         </UndefinedMagicMethod>
         <InvalidReturnType>
@@ -59,6 +61,7 @@
         <PossiblyFalseOperand>
             <errorLevel type="suppress">
                 <file name="src/Helpers/RelationHelper.php" />
+                <file name="src/CheckpointServiceProvider.php" />
             </errorLevel>
         </PossiblyFalseOperand>
         <MissingClosureReturnType>

--- a/src/CheckpointServiceProvider.php
+++ b/src/CheckpointServiceProvider.php
@@ -8,6 +8,12 @@ use Plank\Checkpoint\Commands\StartRevisioning;
 
 class CheckpointServiceProvider extends ServiceProvider
 {
+    protected $models = [
+        \Plank\Checkpoint\Models\Revision::class,
+        \Plank\Checkpoint\Models\Checkpoint::class,
+        \Plank\Checkpoint\Models\Timeline::class,
+    ];
+
     /**
      * Bootstrap the application services.
      */
@@ -52,5 +58,22 @@ class CheckpointServiceProvider extends ServiceProvider
     {
         // Automatically apply the package configuration
         $this->mergeConfigFrom(__DIR__.'/../config/checkpoint.php', 'checkpoint');
+
+        $this->registerModels();
+    }
+
+    /**
+     * Bind user-defined models from config to corresponding package models
+     */
+    public function registerModels()
+    {
+        $config = config('checkpoint.models');
+
+        foreach ($this->models as $model) {
+            $key = lcfirst(substr($model, strrpos($model, '\\') + 1));
+            $this->app->bind($model, function () use ($config, $key) {
+                return new $config[$key];
+            });
+        }
     }
 }

--- a/src/Models/Revision.php
+++ b/src/Models/Revision.php
@@ -144,9 +144,19 @@ class Revision extends MorphPivot
      *
      * @return string
      */
-    public function getCheckpointIdColumn()
+    public function getCheckpointKeyName()
     {
         return static::CHECKPOINT_ID;
+    }
+
+    /**
+     * Get the name of the "timeline id" column.
+     *
+     * @return string
+     */
+    public function getTimelineKeyName()
+    {
+        return static::TIMELINE_ID;
     }
 
     /**
@@ -184,16 +194,23 @@ class Revision extends MorphPivot
     }
 
     /**
+     * Return the associated timeline to this revision - should match the on checkpoint, if set
+     *
+     * @return BelongsTo
+     */
+    public function timeline(): BelongsTo
+    {
+        return $this->belongsTo(get_class(app(Timeline::class)), $this->getTimelineKeyName());
+    }
+
+    /**
      * Return the associated checkpoint/release to this revision
      *
      * @return BelongsTo
      */
     public function checkpoint(): BelongsTo
     {
-        /** @var string $checkpointClass */
-        $checkpointClass = config('checkpoint.models.checkpoint');
-
-        return $this->belongsTo($checkpointClass, $this->getCheckpointIdColumn());
+        return $this->belongsTo(get_class(app(Checkpoint::class)), $this->getCheckpointKeyName());
     }
 
     /**

--- a/src/Models/Revision.php
+++ b/src/Models/Revision.php
@@ -313,20 +313,19 @@ class Revision extends MorphPivot
         $q->withoutGlobalScopes()->selectRaw("max({$this->getKeyName()})")
             ->groupBy(['original_revisionable_id', 'revisionable_type'])->orderByDesc('previous_revision_id');
 
-        /** @var Checkpoint $checkpointClass */
-        $checkpointClass = config('checkpoint.models.checkpoint');
-        $keyname = $checkpointClass::getModel()->getKeyName();
+        $checkpoint = app(Checkpoint::class);
+        $keyname = $checkpoint->getKeyName();
 
-        if ($until instanceof $checkpointClass) {
+        if ($until instanceof $checkpoint) {
             // where in given checkpoint or one of the previous ones
-            $q->whereIn($this->getCheckpointIdColumn(), $checkpointClass::olderThanEquals($until)->select($keyname));
+            $q->whereIn($this->getCheckpointKeyName(), $checkpoint->olderThanEquals($until)->select($keyname));
         } elseif ($until !== null) {
             $q->where($this->getQualifiedCreatedAtColumn(), '<=', $until);
         }
 
-        if ($since instanceof $checkpointClass) {
+        if ($since instanceof $checkpoint) {
             // where in one of the newer checkpoints than given
-            $q->whereIn($this->getCheckpointIdColumn(), $checkpointClass::newerThan($since)->select($keyname));
+            $q->whereIn($this->getCheckpointKeyName(), $checkpoint->newerThan($since)->select($keyname));
         } elseif ($since !== null) {
             $q->where($this->getQualifiedCreatedAtColumn(), '>', $since);
         }

--- a/src/Models/Timeline.php
+++ b/src/Models/Timeline.php
@@ -18,9 +18,18 @@ class Timeline extends Model
      */
     public function checkpoints(): HasMany
     {
-        /** @var Checkpoint|string $checkpointClass */
-        $checkpointClass = config('checkpoint.models.checkpoint');
+        $checkpoint = app(Checkpoint::class);
+        return $this->hasMany(get_class(app(Checkpoint::class)), $checkpoint->getTimelineKeyName());
+    }
 
-        return $this->hasMany($checkpointClass, $checkpointClass::TIMELINE_ID);
+    /**
+     * Get all checkpoints associated with the Timeline
+     *
+     * @return HasMany
+     */
+    public function revisions(): HasMany
+    {
+        $revision = app(Revision::class);
+        return $this->hasMany(get_class($revision), $revision->getTimelineKeyName());
     }
 }

--- a/src/Models/Timeline.php
+++ b/src/Models/Timeline.php
@@ -18,8 +18,10 @@ class Timeline extends Model
      */
     public function checkpoints(): HasMany
     {
-        $checkpoint = app(Checkpoint::class);
-        return $this->hasMany(get_class(app(Checkpoint::class)), $checkpoint->getTimelineKeyName());
+        return $this->hasMany(
+            get_class(app(Checkpoint::class)),
+            app(Checkpoint::class)->getTimelineKeyName()
+        );
     }
 
     /**
@@ -29,7 +31,9 @@ class Timeline extends Model
      */
     public function revisions(): HasMany
     {
-        $revision = app(Revision::class);
-        return $this->hasMany(get_class($revision), $revision->getTimelineKeyName());
+        return $this->hasMany(
+            get_class(app(Revision::class)),
+            app(Revision::class)->getTimelineKeyName()
+        );
     }
 }

--- a/src/Observers/CheckpointObserver.php
+++ b/src/Observers/CheckpointObserver.php
@@ -15,15 +15,10 @@ class CheckpointObserver
      */
     public function updated(Checkpoint $checkpoint)
     {
-        /** @var Checkpoint $revision */
-        $checkpointClass = config('checkpoint.models.checkpoint');
-
-        if ($checkpoint->isDirty($checkpointClass::TIMELINE_ID)) {
-            /** @var Revision $revision */
-            $revision = config('checkpoint.models.revision');
+        if ($checkpoint->isDirty($checkpoint->getTimelineKeyName())) {
 
             $checkpoint->revisions()->update([
-                $revision::TIMELINE_ID => $checkpoint->{$checkpointClass::TIMELINE_ID}
+                app(Revision::class)->getTimelineKeyName() => $checkpoint->getTimelineKey()
             ]);
 
             // Ensure the model has the proper timeline loaded
@@ -43,12 +38,11 @@ class CheckpointObserver
         /** @var Checkpoint $checkpointClass */
         $checkpointClass = config('checkpoint.models.checkpoint');
 
-        /** @var Revision $revision */
-        $revision = config('checkpoint.models.revision');
+        $revision = app(Revision::class);
 
         $checkpoint->revisions()->update([
-            $revision::CHECKPOINT_ID => null,
-            $revision::TIMELINE_ID => null
+            $revision->getCheckpointKeyName() => null,
+            $revision->getTimelineKeyName() => null,
         ]);
 
         $active = $checkpointClass::active();


### PR DESCRIPTION
## Summary

To clean up the constant  `$class = config('checkpoint.models.class')` syntax and hopefully the static analysis too, I'm binding the models listed by users in the config over to their default/package equivalent in the service container.

This also involves changing a bunch of references in different places like model relations, etc. but will continue to ensure that a user-defined model will be used and we can automatically apply any of their global scopes, etc.

### Testing
This change should maintain compatibility and keep all existing tests green but I've also changed the names and added a few helper methods for getting keys of checkpoint and timeline ids on different models.

