### PR TITLE
Support Laravel 9

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,10 +1,7 @@
 name: Psalm
 
 on:
-  push:
-    paths:
-      - '**.php'
-      - 'psalm.xml'
+  workflow_dispatch
 
 jobs:
   psalm:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,12 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [7.4, 8.0]
-        laravel: [6.*, 7.*, 8.*]
+        php: [7.4, 8.0, 8.1]
+        laravel: [6.*, 7.*, 8.*, 9.*]
         stability: [prefer-stable]
         include:
+          - laravel: 9.*
+            testbench: 7.*
           - laravel: 8.*
             testbench: 6.*
           - laravel: 7.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,10 +65,15 @@ jobs:
           path: ~/.composer/cache/files
           key: dependencies-php-${{ matrix.php }}-laravel-${{ matrix.laravel }}-stability-${{ matrix.stability }}-composer-${{ hashFiles('composer.json') }}
 
-      - name: Install dependencies
-        run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --no-interaction
+      - name: Install framework and testbench
+        run: composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+
+      - name: Require correct psalm plugins
+        run: composer require "vimeo/psalm:^4.22" "psalm/plugin-laravel:^1.5.3" --no-interaction --no-update
+        if: ${{ contains(matrix.laravel, '9') }}
+
+      - name: Install other dependencies
+          composer install --${{ matrix.stability }} --no-interaction
 
       - name: Install Legacy Factories Package
         run: composer require "laravel/legacy-factories" --no-interaction --no-update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,15 @@ jobs:
         php: [7.4, 8.0, 8.1]
         laravel: [6.*, 7.*, 8.*, 9.*]
         stability: [prefer-stable]
+        exclude:
+          - laravel: 9.*
+            php: 7.4
+          - laravel: 8.*
+            php: 8.1
+          - laravel: 7.*
+            php: 8.1
+          - laravel: 6.*
+            php: 8.1
         include:
           - laravel: 9.*
             testbench: 7.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,10 +68,6 @@ jobs:
       - name: Install framework and testbench
         run: composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
 
-      - name: Require correct psalm plugins
-        run: composer require "vimeo/psalm:^4.22" "psalm/plugin-laravel:^1.5.3" --dev --no-interaction --no-update
-        if: ${{ contains(matrix.laravel, '9') }}
-
       - name: Install other dependencies
         run: composer update --${{ matrix.stability }} --no-interaction
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
         if: ${{ contains(matrix.laravel, '9') }}
 
       - name: Install other dependencies
-          composer install --${{ matrix.stability }} --no-interaction
+        run: composer install --${{ matrix.stability }} --no-interaction
 
       - name: Install Legacy Factories Package
         run: composer require "laravel/legacy-factories" --no-interaction --no-update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,17 +20,26 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [7.4, 8.0, 8.1]
+        dbal: [^2.6, ^3.3]
         laravel: [6.*, 7.*, 8.*, 9.*]
         stability: [prefer-stable]
         exclude:
           - laravel: 9.*
             php: 7.4
+          - laravel: 9.*
+            dbal: ^2.6
           - laravel: 8.*
             php: 8.1
+          - laravel: 8.*
+            dbal: ^2.6
           - laravel: 7.*
             php: 8.1
+          - laravel: 7.*
+            dbal: ^3.3
           - laravel: 6.*
             php: 8.1
+          - laravel: 6.*
+            dbal: ^3.3
         include:
           - laravel: 9.*
             testbench: 7.*
@@ -66,7 +75,7 @@ jobs:
           key: dependencies-php-${{ matrix.php }}-laravel-${{ matrix.laravel }}-stability-${{ matrix.stability }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Install framework and testbench
-        run: composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+        run: composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "doctrine/dbal:${{ matrix.dbal }}" --no-interaction --no-update
 
       - name: Install other dependencies
         run: composer update --${{ matrix.stability }} --no-interaction

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
         if: ${{ contains(matrix.laravel, '9') }}
 
       - name: Install other dependencies
-        run: composer install --${{ matrix.stability }} --no-interaction
+        run: composer update --${{ matrix.stability }} --no-interaction
 
       - name: Install Legacy Factories Package
         run: composer require "laravel/legacy-factories" --no-interaction --no-update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,7 @@ jobs:
         run: composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
 
       - name: Require correct psalm plugins
-        run: composer require "vimeo/psalm:^4.22" "psalm/plugin-laravel:^1.5.3" --no-interaction --no-update
+        run: composer require "vimeo/psalm:^4.22" "psalm/plugin-laravel:^1.5.3" --dev --no-interaction --no-update
         if: ${{ contains(matrix.laravel, '9') }}
 
       - name: Install other dependencies

--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
     "require": {
         "php": "^7.1.3|^8.0",
         "ext-json": "*",
-        "illuminate/support": "5.8.*|^6.0|^7.0|^8.0"
+        "illuminate/support": "5.8.*|^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "laravel/legacy-factories": "^1.0.4",
-        "orchestra/testbench": "^4.8 || ^5.2 || ^6.0",
+        "orchestra/testbench": "^4.8 || ^5.2 || ^6.0 || ^7.2",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-laravel": "^1.4",
         "vimeo/psalm": "^4.10"

--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,10 @@
         "illuminate/support": "5.8.*|^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
+        "doctrine/dbal": "^3.3",
         "laravel/legacy-factories": "^1.0.4",
         "orchestra/testbench": "^4.8 || ^5.2 || ^6.0 || ^7.2",
-        "phpunit/phpunit": "^9.5",
-        "psalm/plugin-laravel": "^1.4",
-        "vimeo/psalm": "^4.10"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/support": "5.8.*|^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
-        "doctrine/dbal": "^3.3",
+        "doctrine/dbal": "^2.6|^3.3",
         "laravel/legacy-factories": "^1.0.4",
         "orchestra/testbench": "^4.8 || ^5.2 || ^6.0 || ^7.2",
         "phpunit/phpunit": "^9.5"


### PR DESCRIPTION
To Support Laravel 9, we need to bump the version of Illuminate\Support we are requiring as a dependency. Also bump the version of orchestra/testbench to allow tests to run on the Laravel 9 framework.